### PR TITLE
Removed shell invocation for preserve mode and modified tests accordi…

### DIFF
--- a/hpcinstall
+++ b/hpcinstall
@@ -375,11 +375,13 @@ def how_to_call_yourself(args, yourself, pwd, modules_to_load):
     comb_cmd = modules_to_load + " cd " + pwd + "; " + " ".join(args_copy)
 
     if "-p" in args or "--preserve" in args:
-        new_invocation = shell + [comb_cmd]
+        new_invocation = comb_cmd
+        use_shell = True
     else:
         new_invocation = ["ssh","-t","localhost"] + shell + ["'ml purge; " + comb_cmd + "'"]
+        use_shell = False
     
-    return new_invocation
+    return new_invocation, use_shell
 
 # execution starts here
 if __name__ == "__main__":
@@ -390,11 +392,8 @@ if __name__ == "__main__":
     # hack to reset the environment -- assume everything into the environment has been
     # reset, and continue executing "as is" the following `if` did not exist.
     if not options.nossh:
-        sys.exit(
-            subprocess.call(
-                       how_to_call_yourself(sys.argv, script_dir, os.getcwd(), options.modules_to_load)
-                         )
-                )
+        exe_cmd, use_shell = how_to_call_yourself(sys.argv, script_dir, os.getcwd(), options.modules_to_load)
+        sys.exit(subprocess.call(exe_cmd, shell = use_shell))
 
     comp_mpi = identify_compiler_mpi()
     prefix, moduledir = get_prefix_and_moduledir(options, options.prog + "/" + comp_mpi, options.defaults)

--- a/test_hpcinstall.py
+++ b/test_hpcinstall.py
@@ -199,8 +199,8 @@ def test_how_to_call_yourself(stub_os):
     hpcinstall.os = stub_os
     stub_os.environ['SHELL'] = "/bin/bash"
     args = ['./hpcinstall', 'build-example-1.2.3', '-u', 'http://example.com']
-    expected = ['ssh', '-t', 'localhost', '/bin/bash', '-l', '-c',
-                "'ml purge; ml python; ml gnu; cd /the/pwd/; /some/strange/dir/hpcinstall build-example-1.2.3 -u http://example.com --nossh'"]
+    expected = (['ssh', '-t', 'localhost', '/bin/bash', '-l', '-c',
+                "'ml purge; ml python; ml gnu; cd /the/pwd/; /some/strange/dir/hpcinstall build-example-1.2.3 -u http://example.com --nossh'"], False)
     actual = hpcinstall.how_to_call_yourself(args, "/some/strange/dir/", "/the/pwd/", "ml python; ml gnu;")
     assert actual == expected
 
@@ -208,8 +208,7 @@ def test_how_to_call_yourself_with_preserve(stub_os):
     hpcinstall.os = stub_os
     stub_os.environ['SHELL'] = "/bin/bash"
     args = ['./hpcinstall', 'build-example-1.2.3', '-u', '-p', 'http://example.com']
-    expected = ['/bin/bash', '-l', '-c',
-                "ml python; ml gnu; cd /the/pwd/; /some/strange/dir/hpcinstall build-example-1.2.3 -u -p http://example.com --nossh"]
+    expected = ("ml python; ml gnu; cd /the/pwd/; /some/strange/dir/hpcinstall build-example-1.2.3 -u -p http://example.com --nossh", True)
     actual = hpcinstall.how_to_call_yourself(args, "/some/strange/dir/", "/the/pwd/", "ml python; ml gnu;")
     assert actual == expected
 


### PR DESCRIPTION
This change avoids potential headaches with user configurations of .profile and .bashrc setting variables and loading modules, which can cause unexpected behavior if a new shell is created. In this change, the preserve mode uses the existing shell instead of invoking bash/tcsh/etc...

This change is especially important given the modules problem in NCAR/CheyenneModules#15.
