### PR TITLE
Changes to address issues 83 and 85

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,3 +385,4 @@ This section may become reduntant once github includes the tag message in their
 * v1.2            Using x-tunneling when `ssh`ing into localhost, fixed configuration file on Yellowstone, first open source release
 * v1.2.1          Refactored the parse_command_line_argument method and got rid of the nasty ${SUDO_USER} is not expanded bug
 * v1.2.2          Configuration issue on Cheyenne/Laramie: it was not using the correct ldmod environmental variable
+* v1.2.3          Now handles shared-scratch space for test installs and a minor bug fix

--- a/config.hpcinstall.cheyenne.yaml
+++ b/config.hpcinstall.cheyenne.yaml
@@ -1,4 +1,4 @@
-scratch_tree: /glade/scratch
+scratch_tree: /glade/scratch/${USER}/ch
 sw_install_dir: /glade/u/apps/ch/opt/
 mod_install_dir: ~/CheyenneModules/${SUDO_USER}/CheyenneModules/chey
 script_repo: ~/.hpcinstall/chey-install-scripts

--- a/config.hpcinstall.hpcfl.yaml
+++ b/config.hpcinstall.hpcfl.yaml
@@ -1,4 +1,4 @@
-scratch_tree: /scratch
+scratch_tree: /scratch/${USER}/
 sw_install_dir: /ncar/csg/opt/
 mod_install_dir: /ncar/csg/opt/modulefiles/
 sw_install_struct:  ${LMOD_FAMILY_MPI}/${LMOD_MPI_VERSION}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_COMPILER_VERSION}/

--- a/config.hpcinstall.jellystone.yaml
+++ b/config.hpcinstall.jellystone.yaml
@@ -1,4 +1,4 @@
-scratch_tree: /picnic/scratch
+scratch_tree: /picnic/scratch/${USER}/js
 sw_install_dir: /glade/apps/opt/
 mod_install_dir: /glade/apps/opt/modulefiles/js/
 python_cmd: /glade/apps/opt/python/2.7.5/gnu-westmere/4.7.2/bin/python

--- a/config.hpcinstall.laramie.yaml
+++ b/config.hpcinstall.laramie.yaml
@@ -1,4 +1,4 @@
-scratch_tree: /picnic/scratch
+scratch_tree: /picnic/scratch/${USER}/la
 sw_install_dir: /picnic/u/apps/la/opt/
 mod_install_dir: ~/CheyenneModules/${SUDO_USER}/CheyenneModules/la
 script_repo: ~/.hpcinstall/chey-install-scripts

--- a/config.hpcinstall.yellowstone.yaml
+++ b/config.hpcinstall.yellowstone.yaml
@@ -1,4 +1,4 @@
-scratch_tree: /glade/scratch
+scratch_tree: /glade/scratch/${USER}/ys
 sw_install_dir: /glade/apps/opt
 mod_install_dir: /glade/apps/opt/modulefiles/ys
 python_cmd: /glade/apps/opt/python/2.7.7/gnu-westmere/4.8.2/bin/python

--- a/hpcinstall.py
+++ b/hpcinstall.py
@@ -293,7 +293,7 @@ def get_prefix_and_moduledir(options, bin_dep, mod_dep):
         if "HPCI_TEST_BASEPATH" in os.environ:
             basepath = os.environ['HPCI_TEST_BASEPATH']
         else:
-            basepath = default_dirs["scratch_tree"] + os.environ['USER'] + "/test_installs/"
+            basepath = default_dirs["scratch_tree"] + "/test_installs/"
         prefix    = os.path.abspath(basepath + "/" + my_prog + "/" + bin_dep)
         moduledir = os.path.abspath(basepath + "/modulefiles/")
 

--- a/hpcinstall.py
+++ b/hpcinstall.py
@@ -126,14 +126,14 @@ def get_config_data(env_sudo_user):  # sudo_user is dependency only via environm
         failed = 1
     return failed, defaults
 
-def test_modules(modules_to_load, debug):
+def test_modules(modules_to_load, debug, script_name):
     failed = 0
     if subcall(modules_to_load,            # try loading modules
                    stop_on_errors=True,        # stop at the first failure
                    log="/dev/null",            # don't output anything (output already happened in the ssh call)
                    debug=debug,                # use specified debug level
                 ) != 0:
-        print >> sys.stderr, term.bold_red("Modules from " + args.install_script.name + " are not loadable:")
+        print >> sys.stderr, term.bold_red("Modules from " + script_name + " are not loadable:")
         print >> sys.stderr, modules_to_load
         failed = 1
     return failed
@@ -225,7 +225,7 @@ def parse_command_line_arguments(list_of_files):
     # Test requested modules during initial pass
     if not args.nossh:
         if args.defaults['use_modules']:
-            num_failures += test_modules(args.modules_to_load, args.debug)
+            num_failures += test_modules(args.modules_to_load, args.debug, args.install_script.name)
         else:
             args.modules_to_load = ""
 

--- a/install-hpcinstall.cheyenne
+++ b/install-hpcinstall.cheyenne
@@ -1,6 +1,6 @@
 #!/bin/bash
 #HPCI -n hpcinstall
-#HPCI -v 1.2.2
+#HPCI -v 1.2.3
 #HPCI -u https://github.com/NCAR/HPCinstall/
 
 # saving current status of the repo

--- a/install-hpcinstall.jellystone
+++ b/install-hpcinstall.jellystone
@@ -1,6 +1,6 @@
 #!/bin/bash
 #HPCI -n hpcinstall
-#HPCI -v 1.2.2
+#HPCI -v 1.2.3
 #HPCI -u https://github.com/NCAR/HPCinstall/
 
 # jellystone does not have a viable git binary

--- a/install-hpcinstall.laramie
+++ b/install-hpcinstall.laramie
@@ -1,6 +1,6 @@
 #!/bin/bash
 #HPCI -n hpcinstall
-#HPCI -v 1.2.2
+#HPCI -v 1.2.3
 #HPCI -x ml git
 #HPCI -u https://github.com/NCAR/HPCinstall/
 

--- a/install-hpcinstall.yellowstone
+++ b/install-hpcinstall.yellowstone
@@ -1,6 +1,6 @@
 #!/bin/bash
 #HPCI -n hpcinstall
-#HPCI -v 1.2.2
+#HPCI -v 1.2.3
 #HPCI -x ml git
 #HPCI -u https://github.com/NCAR/HPCinstall/
 

--- a/test_hpcinstall.py
+++ b/test_hpcinstall.py
@@ -46,7 +46,7 @@ def dirs():                    # stub dirs
     dirs["sw_install_struct"] = "${COMP}/${COMP_VER}/${MPI}/${MPI_VER}"
     dirs["mod_install_dir"] = "/glade/mods/"
     dirs["mod_install_struct"] = "${MPI}/${MPI_VER}/${COMP}/${COMP_VER}"
-    dirs["scratch_tree"]    = "/glade/scra/"
+    dirs["scratch_tree"]    = "/glade/scra/${USER}/"
     return dirs
 
 @pytest.fixture
@@ -273,17 +273,17 @@ def test_get_prefix_and_moduledir_for_user(dirs, opt, stub_os):
     opt.vers = "1.2.3"
     opt.defaults = dirs
     d = hpcinstall.get_prefix_and_moduledir(opt, "gnu/4.4.1", "gnu/4.4.1")
-    assert d.prefix        == os.path.abspath(dirs["scratch_tree"] + stub_os.environ['USER'] + "/test_installs/foo/1.2.3/gnu/4.4.1") + "/"
-    assert d.basemoduledir == os.path.abspath(dirs["scratch_tree"] + stub_os.environ['USER'] + "/test_installs/modulefiles") + "/"
-    assert d.idepmoduledir == os.path.abspath(dirs["scratch_tree"] + stub_os.environ['USER'] + "/test_installs/modulefiles/idep") + "/"
-    assert d.cdepmoduledir == os.path.abspath(dirs["scratch_tree"] + stub_os.environ['USER'] + "/test_installs/modulefiles/gnu/4.4.1") + "/"
+    assert d.prefix        == os.path.abspath(dirs["scratch_tree"] + "/test_installs/foo/1.2.3/gnu/4.4.1") + "/"
+    assert d.basemoduledir == os.path.abspath(dirs["scratch_tree"] + "/test_installs/modulefiles") + "/"
+    assert d.idepmoduledir == os.path.abspath(dirs["scratch_tree"] + "/test_installs/modulefiles/idep") + "/"
+    assert d.cdepmoduledir == os.path.abspath(dirs["scratch_tree"] + "/test_installs/modulefiles/gnu/4.4.1") + "/"
     assert d.relativeprefix == "/foo/1.2.3/gnu/4.4.1/"
 
     d = hpcinstall.get_prefix_and_moduledir(opt, "gnu/4.4.1/mpi/1.2.3", "mpi/1.2.3/gnu/4.4.1")
-    assert d.prefix        == os.path.abspath(dirs["scratch_tree"] + stub_os.environ['USER'] + "/test_installs/foo/1.2.3/gnu/4.4.1/mpi/1.2.3") + "/"
-    assert d.basemoduledir == os.path.abspath(dirs["scratch_tree"] + stub_os.environ['USER'] + "/test_installs/modulefiles") + "/"
-    assert d.idepmoduledir == os.path.abspath(dirs["scratch_tree"] + stub_os.environ['USER'] + "/test_installs/modulefiles/idep") + "/"
-    assert d.cdepmoduledir == os.path.abspath(dirs["scratch_tree"] + stub_os.environ['USER'] + "/test_installs/modulefiles/mpi/1.2.3/gnu/4.4.1") + "/"
+    assert d.prefix        == os.path.abspath(dirs["scratch_tree"] + "/test_installs/foo/1.2.3/gnu/4.4.1/mpi/1.2.3") + "/"
+    assert d.basemoduledir == os.path.abspath(dirs["scratch_tree"] + "/test_installs/modulefiles") + "/"
+    assert d.idepmoduledir == os.path.abspath(dirs["scratch_tree"] + "/test_installs/modulefiles/idep") + "/"
+    assert d.cdepmoduledir == os.path.abspath(dirs["scratch_tree"] + "/test_installs/modulefiles/mpi/1.2.3/gnu/4.4.1") + "/"
     assert d.relativeprefix == "/foo/1.2.3/gnu/4.4.1/mpi/1.2.3/"
 
     stub_os.environ['HPCI_TEST_BASEPATH'] = "/I_want_this_tree_instead"


### PR DESCRIPTION
Test installs go into system specific scratch path. Additionally, script name should be used module load error as intended. Created new 1.2.3 tag for install to clusters.