### PR TITLE
Use LMOD version vars and add DAV

### DIFF
--- a/config.hpcinstall.cheyenne.yaml
+++ b/config.hpcinstall.cheyenne.yaml
@@ -2,5 +2,5 @@ scratch_tree: /glade/scratch/${USER}/ch
 sw_install_dir: /glade/u/apps/ch/opt/
 mod_install_dir: ~/CheyenneModules/${SUDO_USER}/CheyenneModules/chey
 script_repo: ~/.hpcinstall/chey-install-scripts
-sw_install_struct:  ${LMOD_FAMILY_MPI}/${LMOD_MPI_VERSION}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_COMPILER_VERSION}/
-mod_install_struct: ${LMOD_FAMILY_MPI}/${LMOD_MPI_VERSION}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_COMPILER_VERSION}/
+sw_install_struct:  ${LMOD_FAMILY_MPI}/${LMOD_FAMILY_MPI_VERSION}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_COMPILER_VERSION}/
+mod_install_struct: ${LMOD_FAMILY_MPI}/${LMOD_FAMILY_MPI_VERSION}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_COMPILER_VERSION}/

--- a/config.hpcinstall.dav.yaml
+++ b/config.hpcinstall.dav.yaml
@@ -1,0 +1,7 @@
+scratch_tree: /glade/scratch/${USER}/dav
+sw_install_dir: /glade/u/apps/dav/opt/
+mod_install_dir: ~/CheyenneModules/${SUDO_USER}/CheyenneModules/dav
+script_repo: ~/.hpcinstall/dav-install-scripts
+sw_install_struct:  ${LMOD_FAMILY_MPI}/${LMOD_FAMILY_MPI_VERSION}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_COMPILER_VERSION}/
+mod_install_struct: ${LMOD_FAMILY_MPI}/${LMOD_FAMILY_MPI_VERSION}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_COMPILER_VERSION}/
+

--- a/hpcinstall.py
+++ b/hpcinstall.py
@@ -408,15 +408,15 @@ def verify_compiler_mpi(options):
     mpi = ""
     try:
         if compiler:
-            compiler += "/" + os.environ['LMOD_COMPILER_VERSION'].strip()
+            compiler += "/" + os.environ['LMOD_FAMILY_COMPILER_VERSION'].strip()
             mpi = os.environ.get('LMOD_FAMILY_MPI','').strip()
             if mpi:
-                mpi += "/" + os.environ['LMOD_MPI_VERSION'].strip() + "/"
+                mpi += "/" + os.environ['LMOD_FAMILY_MPI_VERSION'].strip() + "/"
     except KeyError, ke:
         for broken_key in ke.args:
             print >> sys.stderr, term.bold_red("Error: " + broken_key + " not set")
         sys.exit(1)
-    vars = ('LMOD_FAMILY_COMPILER', 'LMOD_COMPILER_VERSION', 'LMOD_FAMILY_MPI', 'LMOD_MPI_VERSION')
+    vars = ('LMOD_FAMILY_COMPILER', 'LMOD_FAMILY_COMPILER_VERSION', 'LMOD_FAMILY_MPI', 'LMOD_FAMILY_MPI_VERSION')
     for v in vars:
         if not v in options.defaults['sw_install_struct']:
             print >> sys.stderr, term.on_black_bold_yellow("Warning: " + v + " not used in sw_install_struct of config.hpcinstall.yaml")


### PR DESCRIPTION
Our only Lmod version with LMOD_FAMILY_VERSION_... is going away soon, so let's use the autogenerated variables and stop adding the others to our modules.

Also, added Pat's DAV config file.